### PR TITLE
Avoid downgrading existing wheel installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,6 @@ terminado==0.6
 tornado==4.3
 traitlets==4.2.2
 wcwidth==0.1.7
-wheel==0.24.0
+wheel>=0.24.0
 widgetsnbextension==1.2.3
 wordcloud==1.2.1


### PR DESCRIPTION
Wheel is part of a standard python environment - so currently doing a `pip install -r requirements.txt` on a freshly installed venv prints something like:

```
Installing collected packages: wheel
  Found existing installation: wheel 0.29.0
    Uninstalling wheel-0.29.0:
      Successfully uninstalled wheel-0.29.0
Successfully installed wheel-0.24.0
```
