### PR TITLE
Mistake when not using lower() before checking with stopwords list

### DIFF
--- a/notebooks/01 recipes_exploratory_analysis.ipynb
+++ b/notebooks/01 recipes_exploratory_analysis.ipynb
@@ -247,9 +247,9 @@
     "from nltk.stem import PorterStemmer\n",
     "\n",
     "stemmer = PorterStemmer()\n",
+    "all_tokens = [t.lower() for t in all_tokens]\n",
     "\n",
-    "tokens_normalised = [stemmer.stem(t.lower()) for t in all_tokens\n",
-    "                     if t not in stop_list]\n",
+    "tokens_normalised = [t for t in all_tokens if t not in stop_list]\n",
     "\n",
     "total_term_frequency_normalised = Counter(tokens_normalised)\n",
     "\n",
@@ -374,7 +374,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.1"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The comparison of terms with the stop-words list was incorrect as we didn't lowercase all the cases before.
